### PR TITLE
Fix DatabaseDispatcherScript Alerts to add msg ID

### DIFF
--- a/server/src/com/mirth/connect/connectors/jdbc/DatabaseDispatcherScript.java
+++ b/server/src/com/mirth/connect/connectors/jdbc/DatabaseDispatcherScript.java
@@ -150,7 +150,7 @@ public class DatabaseDispatcherScript implements DatabaseDispatcherDelegate {
                 responseStatus = Status.QUEUED;
 
                 logger.error("Error evaluating " + connectorProperties.getName() + " (" + connectorProperties.getName() + " \"" + connector.getDestinationName() + "\" on channel " + connector.getChannelId() + ").", e);
-                eventController.dispatchEvent(new ErrorEvent(connector.getChannelId(), connector.getMetaDataId(), null, ErrorEventType.DESTINATION_CONNECTOR, connector.getDestinationName(), connectorProperties.getName(), "Error evaluating " + connectorProperties.getName(), e));
+                eventController.dispatchEvent(new ErrorEvent(connector.getChannelId(), connector.getMetaDataId(), connectorMessage.getMessageId(), ErrorEventType.DESTINATION_CONNECTOR, connector.getDestinationName(), connectorProperties.getName(), "Error evaluating " + connectorProperties.getName(), e));
             } finally {
                 Context.exit();
             }


### PR DESCRIPTION
This fixes #4406 by passing the messageId from the ConnectorMessage instead of null when creating the ErrorEvent.