### PR TITLE
Reading the keystore.type from mirth.properties

### DIFF
--- a/server/src/com/mirth/connect/server/MirthWebServer.java
+++ b/server/src/com/mirth/connect/server/MirthWebServer.java
@@ -373,7 +373,7 @@ public class MirthWebServer extends Server {
     }
 
     private ServerConnector createSSLConnector(String name, PropertiesConfiguration mirthProperties) throws Exception {
-        KeyStore keyStore = KeyStore.getInstance("JCEKS");
+        KeyStore keyStore = KeyStore.getInstance(mirthProperties.getString("keystore.type"));
         FileInputStream is = new FileInputStream(new File(mirthProperties.getString("keystore.path")));
         try {
             keyStore.load(is, mirthProperties.getString("keystore.storepass").toCharArray());

--- a/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
+++ b/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
@@ -1112,7 +1112,7 @@ public class DefaultConfigurationController extends ConfigurationController {
             if (MigrationUtil.compareVersions("2.2.0", getServerVersion()) == 1) {
                 keyStore = KeyStore.getInstance("JKS");
             } else {
-                keyStore = KeyStore.getInstance("JCEKS");
+                keyStore = KeyStore.getInstance(mirthConfig.getString("keystore.type"));
             }
 
             if (keyStoreFile.exists()) {


### PR DESCRIPTION
The mirth.properties file has a field keystore.type that is used to
specify the type of the keystore file. Currently it is unused, and
instead the type JCEKS is hardcoded in a few places.

This commit makes it so that the file type is correctly read from
the properties file.