### PR TITLE
Commented 2 unnecessary indexes present in a few D_MC and D_MM tables.

### DIFF
--- a/donkey/donkeydbconf/derby.xml
+++ b/donkey/donkeydbconf/derby.xml
@@ -48,11 +48,11 @@
 	<query id="createConnectorMessageTableIndex3">
 		CREATE INDEX D_MM${localChannelId}_INDEX3 ON D_MM${localChannelId}(ID, STATUS, SERVER_ID)
 	</query>
-	
+        <!-- The index has the same column as the first column in the Primary Key and no query orders by this column. There is no need for this index.
 	<query id="createConnectorMessageTableIndex4">
 		CREATE INDEX D_MM${localChannelId}_FKI ON D_MM${localChannelId}(MESSAGE_ID)
 	</query>
-	
+	-->
 	<query id="createMessageContentTable">
 		CREATE TABLE D_MC${localChannelId} (
 	        METADATA_ID INTEGER NOT NULL,
@@ -65,11 +65,11 @@
 	        CONSTRAINT D_MC${localChannelId}_FKEY FOREIGN KEY(MESSAGE_ID, METADATA_ID) REFERENCES D_MM${localChannelId}(MESSAGE_ID, ID) ON DELETE RESTRICT
         )
 	</query>
-	
+        <!-- The index has the same 2 columns in the same order as the Primary Key. This index is redundant and unnecessary.
 	<query id="createMessageContentTableIndex1">
 		CREATE INDEX D_MC${localChannelId}_FKI ON D_MC${localChannelId}(MESSAGE_ID, METADATA_ID)
 	</query>
-	
+	-->
 	<query id="createMessageCustomMetaDataTable">
 		CREATE TABLE D_MCM${localChannelId} (
 	        METADATA_ID INTEGER NOT NULL,

--- a/donkey/donkeydbconf/mysql.xml
+++ b/donkey/donkeydbconf/mysql.xml
@@ -48,11 +48,12 @@
 	<query id="createConnectorMessageTableIndex3">
 		CREATE INDEX D_MM${localChannelId}_INDEX3 ON D_MM${localChannelId}(ID, STATUS, SERVER_ID)
 	</query>
-	
+        <!-- The table Primary Key has the same colum as first column and there is no query ordering by this column. This index is redundant in MySQL.
+        How to find it: https://www.percona.com/blog/2012/06/20/find-and-remove-duplicate-indexes/
 	<query id="createConnectorMessageTableIndex4">
 		CREATE INDEX D_MM${localChannelId}_FKI ON D_MM${localChannelId}(MESSAGE_ID)
 	</query>
-	
+        -->	
 	<query id="createMessageContentTable">
 		CREATE TABLE D_MC${localChannelId} (
 	        METADATA_ID INTEGER NOT NULL,
@@ -65,11 +66,12 @@
 	        CONSTRAINT D_MC${localChannelId}_FKEY FOREIGN KEY(MESSAGE_ID, METADATA_ID) REFERENCES D_MM${localChannelId}(MESSAGE_ID, ID) ON DELETE CASCADE
         ) ENGINE=InnoDB;
 	</query>
-	
+	<!-- The table Primary Key has the same columns in the same order. This index is redundant in MySQL.
+	How to find it: https://www.percona.com/blog/2012/06/20/find-and-remove-duplicate-indexes/
 	<query id="createMessageContentTableIndex1">
 		CREATE INDEX D_MC${localChannelId}_FKI ON D_MC${localChannelId}(MESSAGE_ID, METADATA_ID)
 	</query>
-	
+        -->	
 	<query id="createMessageCustomMetaDataTable">
 		CREATE TABLE D_MCM${localChannelId} (
 	        METADATA_ID INTEGER NOT NULL,

--- a/donkey/donkeydbconf/oracle.xml
+++ b/donkey/donkeydbconf/oracle.xml
@@ -48,11 +48,11 @@
 	<query id="createConnectorMessageTableIndex3">
 		CREATE INDEX D_MM${localChannelId}_INDEX3 ON D_MM${localChannelId}(ID, STATUS, SERVER_ID)
 	</query>
-	
+        <!-- Index has the same column as the first column in Primary Key. There is no query in the system using Order By this column in this table. There is no need for this index.	
 	<query id="createConnectorMessageTableIndex4">
 		CREATE INDEX D_MM${localChannelId}_FKI ON D_MM${localChannelId}(MESSAGE_ID)
 	</query>
-	
+	-->
 	<query id="createMessageContentTable">
 		CREATE TABLE D_MC${localChannelId} (
 	        METADATA_ID NUMBER(10) NOT NULL,
@@ -65,11 +65,11 @@
 	        CONSTRAINT D_MC${localChannelId}_FKEY FOREIGN KEY(MESSAGE_ID, METADATA_ID) REFERENCES D_MM${localChannelId}(MESSAGE_ID, ID) ON DELETE CASCADE
         )
 	</query>
-	
+        <!-- Index has the same columns in the same order as Primary Key. There is no need for this index.	
 	<query id="createMessageContentTableIndex1">
 		CREATE INDEX D_MC${localChannelId}_FKI ON D_MC${localChannelId}(MESSAGE_ID, METADATA_ID)
 	</query>
-
+        -->
 	<query id="createMessageCustomMetaDataTable">
 		CREATE TABLE D_MCM${localChannelId} (
 	        METADATA_ID NUMBER(10) NOT NULL,

--- a/donkey/donkeydbconf/postgres.xml
+++ b/donkey/donkeydbconf/postgres.xml
@@ -48,11 +48,11 @@
 	<query id="createConnectorMessageTableIndex3">
 		CREATE INDEX D_MM${localChannelId}_INDEX3 ON D_MM${localChannelId} USING BTREE (ID, STATUS, SERVER_ID)
 	</query>
-	
+        <!-- Index is using the exact same column as the first column in Primary Key and there is no query ordering by this column. The index is not necessary.	
 	<query id="createConnectorMessageTableIndex4">
 		CREATE INDEX D_MM${localChannelId}_FKI ON D_MM${localChannelId} USING BTREE (MESSAGE_ID)
 	</query>
-	
+	-->
 	<query id="createMessageContentTable">
 		CREATE TABLE D_MC${localChannelId} (
 	        METADATA_ID INTEGER NOT NULL,
@@ -65,11 +65,11 @@
 	        CONSTRAINT D_MC${localChannelId}_FKEY FOREIGN KEY(MESSAGE_ID, METADATA_ID) REFERENCES D_MM${localChannelId}(MESSAGE_ID, ID) ON DELETE CASCADE
         );
 	</query>
-	
+        <!-- Index has the exact same columns in same order as the Primary Key. This index is not necessary.	
 	<query id="createMessageContentTableIndex1">
 		CREATE INDEX D_MC${localChannelId}_FKI ON D_MC${localChannelId} USING BTREE (MESSAGE_ID, METADATA_ID)
 	</query>
-	
+	-->
 	<query id="createMessageCustomMetaDataTable">
 		CREATE TABLE D_MCM${localChannelId} (
 	        METADATA_ID INTEGER NOT NULL,

--- a/donkey/donkeydbconf/sqlserver.xml
+++ b/donkey/donkeydbconf/sqlserver.xml
@@ -48,11 +48,11 @@
 	<query id="createConnectorMessageTableIndex3">
 		CREATE INDEX D_MM${localChannelId}_INDEX3 ON D_MM${localChannelId}(ID, STATUS, SERVER_ID)
 	</query>
-	
+        <!-- The indexed column is the first column in the Primary Key and there is no query ordering by it. This index is redundant.	
 	<query id="createConnectorMessageTableIndex4">
 		CREATE INDEX D_MM${localChannelId}_FKI ON D_MM${localChannelId}(MESSAGE_ID)
 	</query>
-	
+	-->
 	<query id="createMessageContentTable">
 		CREATE TABLE D_MC${localChannelId} (
 	        METADATA_ID INTEGER NOT NULL,
@@ -65,11 +65,11 @@
 	        CONSTRAINT D_MC${localChannelId}_FKEY FOREIGN KEY(MESSAGE_ID, METADATA_ID) REFERENCES D_MM${localChannelId}(MESSAGE_ID, ID) ON DELETE CASCADE
         )
 	</query>
-	
+        <!-- The index has the same columns in same order as the Primary Key. There is no need for this index.	
 	<query id="createMessageContentTableIndex1">
 		CREATE INDEX D_MC${localChannelId}_FKI ON D_MC${localChannelId}(MESSAGE_ID, METADATA_ID)
 	</query>
-
+        -->
 	<query id="createMessageCustomMetaDataTable">
 		CREATE TABLE D_MCM${localChannelId} (
 	        METADATA_ID INTEGER NOT NULL,


### PR DESCRIPTION
As described in Issue 4551 there are indexes that uses the same first column or columns as the Primary Key indexes. This make them unnecessary. They only slow down DMLs and uses storage.
I commented, not deleted, them. But if you want I can delete. It is quite hard to test this, as nothing in application behavior will change.