### PR TITLE
Timestamps that don't include am/pm should use 24-hour rather than 12-hour format

### DIFF
--- a/donkey/src/test/java/com/mirth/connect/donkey/test/DonkeyDaoTests.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/test/DonkeyDaoTests.java
@@ -230,7 +230,7 @@ public class DonkeyDaoTests {
                 try {
                     TestUtils.assertDatesEqual(result.getTimestamp("received_date").getTime(), connectorMessage.getReceivedDate().getTimeInMillis());
                 } catch (AssertionError e) {
-                    SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss:SSS");
+                    SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
                     logger.error("database received_date: " + format.format(result.getTimestamp("received_date").getTime()) + ", connector message received_date: " + format.format(connectorMessage.getReceivedDate().getTimeInMillis()));
                     throw e;
                 }

--- a/donkey/src/test/java/com/mirth/connect/donkey/test/util/TestUtils.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/test/util/TestUtils.java
@@ -609,7 +609,7 @@ public class TestUtils {
     }
 
     public static void assertDatesEqual(long timestamp1, long timestamp2) {
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd hh:mm");
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm");
         String date1String = format.format(timestamp1);
         String date2String = format.format(timestamp2);
 

--- a/server/src/com/mirth/connect/plugins/dashboardstatus/ConnectionLogItem.java
+++ b/server/src/com/mirth/connect/plugins/dashboardstatus/ConnectionLogItem.java
@@ -15,7 +15,7 @@ import java.text.SimpleDateFormat;
 @SuppressWarnings("serial")
 public class ConnectionLogItem implements Serializable {
 
-    public static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.SSS");
+    public static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
     private Long logId;
     private String serverId;

--- a/server/src/com/mirth/connect/plugins/dashboardstatus/DefaultConnectionLogController.java
+++ b/server/src/com/mirth/connect/plugins/dashboardstatus/DefaultConnectionLogController.java
@@ -113,7 +113,7 @@ public class DefaultConnectionLogController extends ConnectionStatusLogControlle
                 connectorStateMap.put(connectorId, new Object[] { color, stateString });
             }
 
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.SSS");
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
             String channelName = "";
             String connectorType = "";
 

--- a/server/src/com/mirth/connect/plugins/serverlog/ServerLogItem.java
+++ b/server/src/com/mirth/connect/plugins/serverlog/ServerLogItem.java
@@ -17,7 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class ServerLogItem implements Serializable {
 
-    public static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS");
+    public static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
     private String serverId;
     private Long id;

--- a/webadmin/src/com/mirth/connect/webadmin/utils/DateDecorator.java
+++ b/webadmin/src/com/mirth/connect/webadmin/utils/DateDecorator.java
@@ -20,7 +20,7 @@ import org.displaytag.exception.DecoratorException;
 import org.displaytag.properties.MediaTypeEnum;
 
 public class DateDecorator implements DisplaytagColumnDecorator {
-    private SimpleDateFormat simpleDate = new SimpleDateFormat("MM-dd-yyyy hh:mm:ss:SSS");
+    private SimpleDateFormat simpleDate = new SimpleDateFormat("MM-dd-yyyy HH:mm:ss.SSS");
 
     private String formatDate(Date date) {
         return simpleDate.format(date);


### PR DESCRIPTION
This fixes the timestamps in:
* Server Log panel
* Connection Log panel
* DateDecorator (I'm not sure what impact that has on the UI)
* Some automated tests

Fixes https://github.com/nextgenhealthcare/connect/issues/4124