### PR TITLE
Send ServerEvent when server startup has finished

### DIFF
--- a/server/src/com/mirth/connect/server/Mirth.java
+++ b/server/src/com/mirth/connect/server/Mirth.java
@@ -390,6 +390,7 @@ public class Mirth extends Thread {
         }
 
         configurationController.setStatus(ConfigurationController.STATUS_OK);
+        eventController.dispatchEvent(new ServerEvent(configurationController.getServerId(), "Server startup complete"));
         printSplashScreen();
 
         // Send usage stats once a day.


### PR DESCRIPTION
An event is created early in the startup process, but there is not an event sent when startup completes.

resolves #4870 