### PR TITLE
Add default impl for getObjectsForSwaggerExamples in ServicePlugin

### DIFF
--- a/server/src/com/mirth/connect/connectors/tcp/TcpServicePlugin.java
+++ b/server/src/com/mirth/connect/connectors/tcp/TcpServicePlugin.java
@@ -50,10 +50,4 @@ public class TcpServicePlugin implements ServicePlugin {
     public ExtensionPermission[] getExtensionPermissions() {
         return null;
     }
-    
-    @Override
-    public Map<String, Object> getObjectsForSwaggerExamples() {
-    	// TODO Auto-generated method stub
-    	return null;
-    }
 }

--- a/server/src/com/mirth/connect/plugins/ServicePlugin.java
+++ b/server/src/com/mirth/connect/plugins/ServicePlugin.java
@@ -59,7 +59,11 @@ public interface ServicePlugin extends ServerPlugin {
     /**
      * Returns a map of strings to example objects for use in populating swagger's examples.
      * 
+     * May return null if no examples are provided. Default implementation returns null.
+     * 
      * @return
      */
-    public Map<String, Object> getObjectsForSwaggerExamples();
+    default public Map<String, Object> getObjectsForSwaggerExamples() {
+        return null;
+    }
 }

--- a/server/src/com/mirth/connect/plugins/dashboardstatus/DashboardConnectorStatusMonitor.java
+++ b/server/src/com/mirth/connect/plugins/dashboardstatus/DashboardConnectorStatusMonitor.java
@@ -63,10 +63,4 @@ public class DashboardConnectorStatusMonitor implements ServicePlugin {
         ExtensionPermission viewPermission = new ExtensionPermission(PLUGIN_POINT, PERMISSION_VIEW, "Displays the connection status and history of the selected channel on the Dashboard.", OperationUtil.getOperationNamesForPermission(PERMISSION_VIEW, DashboardConnectorStatusServletInterface.class), new String[] {});
         return new ExtensionPermission[] { viewPermission };
     }
-    
-    @Override
-    public Map<String, Object> getObjectsForSwaggerExamples() {
-    	// TODO Auto-generated method stub
-    	return null;
-    }
 }

--- a/server/src/com/mirth/connect/plugins/datapruner/DataPrunerService.java
+++ b/server/src/com/mirth/connect/plugins/datapruner/DataPrunerService.java
@@ -111,10 +111,4 @@ public class DataPrunerService implements ServicePlugin {
 
         return new ExtensionPermission[] { viewPermission, savePermission, startStopPermission };
     }
-    
-    @Override
-    public Map<String, Object> getObjectsForSwaggerExamples() {
-    	// TODO Auto-generated method stub
-    	return null;
-    }
 }

--- a/server/src/com/mirth/connect/plugins/globalmapviewer/GlobalMapProvider.java
+++ b/server/src/com/mirth/connect/plugins/globalmapviewer/GlobalMapProvider.java
@@ -51,10 +51,4 @@ public class GlobalMapProvider implements ServicePlugin {
 
     @Override
     public void init(Properties properties) {}
-    
-    @Override
-    public Map<String, Object> getObjectsForSwaggerExamples() {
-    	// TODO Auto-generated method stub
-    	return null;
-    }
 }

--- a/server/src/com/mirth/connect/plugins/httpauth/HttpAuthServicePlugin.java
+++ b/server/src/com/mirth/connect/plugins/httpauth/HttpAuthServicePlugin.java
@@ -51,10 +51,4 @@ public class HttpAuthServicePlugin implements ServicePlugin {
     public ExtensionPermission[] getExtensionPermissions() {
         return null;
     }
-    
-    @Override
-    public Map<String, Object> getObjectsForSwaggerExamples() {
-    	// TODO Auto-generated method stub
-    	return null;
-    }
 }

--- a/server/src/com/mirth/connect/plugins/serverlog/ServerLogProvider.java
+++ b/server/src/com/mirth/connect/plugins/serverlog/ServerLogProvider.java
@@ -90,10 +90,4 @@ public class ServerLogProvider implements ServicePlugin {
         ExtensionPermission viewPermission = new ExtensionPermission(PLUGIN_POINT, PERMISSION_VIEW, "Displays the contents of the Server Log on the Dashboard.", OperationUtil.getOperationNamesForPermission(PERMISSION_VIEW, ServerLogServletInterface.class), new String[] {});
         return new ExtensionPermission[] { viewPermission };
     }
-
-    @Override
-    public Map<String, Object> getObjectsForSwaggerExamples() {
-        // TODO Auto-generated method stub
-        return null;
-    }
 }

--- a/server/test/com/mirth/connect/server/controllers/ServerConfigurationRestorerTest.java
+++ b/server/test/com/mirth/connect/server/controllers/ServerConfigurationRestorerTest.java
@@ -912,12 +912,6 @@ public class ServerConfigurationRestorerTest {
         public ExtensionPermission[] getExtensionPermissions() {
             return null;
         }
-        
-        @Override
-        public Map<String, Object> getObjectsForSwaggerExamples() {
-        	// TODO Auto-generated method stub
-        	return null;
-        }
     }
 
     private class TestResourceProperties extends ResourceProperties {


### PR DESCRIPTION
The ServicePlugin interface included an additional method since version 3.9.0 in commit https://github.com/nextgenhealthcare/connect/commit/bc9c18f7392644438aa765b0f7fa4e164c93f8d1, causing any classes implementing this interface to require updating. This broke multiple 3rd-party plugins which otherwise should have been able to be compiled against newer mirth versions.

I can only assume that this change was to facilitate a commercial plugin, because all of the open-source implementations contain an auto-generated method stub which returns null.

In order to avoid breakage with other plugins and to reduce overall code size, this PR provides a default implementation for the method which returns null and removes all of the now unnecessary method stubs.

resolves #4869 