### PR TITLE
Fix java.lang.NoClassDefFoundError: java/sql/Driver when running on J…

### DIFF
--- a/server/src/com/mirth/connect/server/util/javascript/MirthContextFactory.java
+++ b/server/src/com/mirth/connect/server/util/javascript/MirthContextFactory.java
@@ -108,7 +108,7 @@ public class MirthContextFactory extends ContextFactory {
         if (isolatedClassLoader == null && ArrayUtils.isNotEmpty(urls)) {
             synchronized (this) {
                 if (isolatedClassLoader == null) {
-                    isolatedClassLoader = new URLClassLoader(urls, null);
+                    isolatedClassLoader = new URLClassLoader(urls, ClassLoader.getSystemClassLoader());
                 }
             }
         }


### PR DESCRIPTION
Fix java.lang.NoClassDefFoundError: java/sql/Driver when running on JDK9+
Details see: https://github.com/nextgenhealthcare/connect/discussions/5079