### PR TITLE
Update Slack Registration link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   - [What's New in Mirth Connect](https://github.com/nextgenhealthcare/connect/wiki/Release-Notes)
 - [Forums](https://forums.mirthproject.io/)
 - [Slack Channel](https://mirthconnect.slack.com/) 
-  - [Slack Registration](https://mirthconnect.herokuapp.com)
+  - [Slack Registration](https://join.slack.com/t/mirthconnect/shared_invite/zt-1prqon9tg-UQ_~6AsV8IwdITTo3z1aoA)
 
 ------------
 


### PR DESCRIPTION
This is an update to change the Slack Channel registration from the broken Heroku link to a direct Slack invitation

This is a response to [Issue 5696](https://github.com/nextgenhealthcare/connect/issues/5696)