### PR TITLE
#5004 Maintain consistent element order in exports

### DIFF
--- a/donkey/src/main/java/com/mirth/connect/donkey/model/message/MapContent.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/model/message/MapContent.java
@@ -9,11 +9,11 @@
 
 package com.mirth.connect.donkey.model.message;
 
-import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.Map;
 
 public class MapContent extends Content {
-    private Object content = new HashMap<String, Object>();
+    private Object content = new TreeMap<String, Object>();
     private transient boolean persisted = false;
 
     public MapContent() {

--- a/donkey/src/main/java/com/mirth/connect/donkey/util/MapUtil.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/util/MapUtil.java
@@ -9,7 +9,7 @@
 
 package com.mirth.connect.donkey.util;
 
-import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -61,7 +61,7 @@ public class MapUtil {
             try {
                 return serializer.serialize(map);
             } catch (Exception e) {
-                Map<String, Object> newMap = new HashMap<String, Object>();
+                Map<String, Object> newMap = new TreeMap<String, Object>();
 
                 for (Entry<String, Object> entry : map.entrySet()) {
                     Object value = entry.getValue();
@@ -108,7 +108,7 @@ public class MapUtil {
          * If an exception occurs while deserializing, we build up a new map manually, attempting to
          * deserialize each entry and replacing entries that fail with their string representations.
          */
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map = new TreeMap<String, Object>();
 
         for (DonkeyElement entry : mapElement.getChildElements()) {
             if (!entry.getNodeName().equalsIgnoreCase("entry")) {

--- a/server/src/com/mirth/connect/model/codetemplates/CodeTemplateContextSet.java
+++ b/server/src/com/mirth/connect/model/codetemplates/CodeTemplateContextSet.java
@@ -12,7 +12,7 @@ package com.mirth.connect.model.codetemplates;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.TreeSet;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -25,7 +25,7 @@ public class CodeTemplateContextSet implements Set<ContextType>, Serializable {
     }
 
     public CodeTemplateContextSet(Collection<ContextType> contextTypes) {
-        delegate = new HashSet<ContextType>(contextTypes);
+        delegate = new TreeSet<ContextType>(contextTypes);
     }
 
     public CodeTemplateContextSet addContext(ContextType... contextTypes) {

--- a/server/src/com/mirth/connect/model/codetemplates/CodeTemplateLibrary.java
+++ b/server/src/com/mirth/connect/model/codetemplates/CodeTemplateLibrary.java
@@ -15,7 +15,7 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.TreeSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,8 +46,8 @@ public class CodeTemplateLibrary implements Serializable, Migratable, Purgable, 
 
     public CodeTemplateLibrary() {
         id = UUID.randomUUID().toString();
-        enabledChannelIds = new HashSet<String>();
-        disabledChannelIds = new HashSet<String>();
+        enabledChannelIds = new TreeSet<String>();
+        disabledChannelIds = new TreeSet<String>();
         codeTemplates = new ArrayList<CodeTemplate>();
     }
 
@@ -58,8 +58,8 @@ public class CodeTemplateLibrary implements Serializable, Migratable, Purgable, 
         lastModified = library.getLastModified();
         description = library.getDescription();
         includeNewChannels = library.isIncludeNewChannels();
-        enabledChannelIds = new HashSet<String>(library.getEnabledChannelIds());
-        disabledChannelIds = new HashSet<String>(library.getDisabledChannelIds());
+        enabledChannelIds = new TreeSet<String>(library.getEnabledChannelIds());
+        disabledChannelIds = new TreeSet<String>(library.getDisabledChannelIds());
         codeTemplates = new ArrayList<CodeTemplate>();
         if (CollectionUtils.isNotEmpty(library.getCodeTemplates())) {
             for (CodeTemplate codeTemplate : library.getCodeTemplates()) {

--- a/server/src/com/mirth/connect/model/converters/MapContentConverter.java
+++ b/server/src/com/mirth/connect/model/converters/MapContentConverter.java
@@ -53,7 +53,7 @@ public class MapContentConverter extends ReflectionConverter {
             try {
                 DonkeyElement mapElement = new DonkeyElement(serializedMap);
                 mapElement.setNodeName("content");
-                mapElement.setAttribute("class", "map");
+                mapElement.setAttribute("class", "tree-map");
                 copier.copy(new XppReader(new StringReader(mapElement.toXml()), new MXParser()), writer);
             } catch (DonkeyElementException e) {
                 throw new SerializerException(e);


### PR DESCRIPTION
Initial testing by @jonbartels showed promise. Should be unit testable, but none provided.