### PR TITLE
#6261 add two vars to the alert template variable list

### DIFF
--- a/client/src/com/mirth/connect/client/ui/alert/DefaultAlertEditPanel.java
+++ b/client/src/com/mirth/connect/client/ui/alert/DefaultAlertEditPanel.java
@@ -106,6 +106,8 @@ public class DefaultAlertEditPanel extends AlertEditPanel {
         variables.add("alertId");
         variables.add("alertName");
         variables.add("serverId");
+        variables.add("serverName");
+        variables.add("environmentName");
         variables.add("globalMapVariable");
         variables.add("date");
 

--- a/core-server-plugins/src/com/mirth/connect/server/alert/Alert.java
+++ b/core-server-plugins/src/com/mirth/connect/server/alert/Alert.java
@@ -9,19 +9,27 @@
 
 package com.mirth.connect.server.alert;
 
+import static java.util.Map.entry;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.velocity.tools.generic.DateTool;
 
+import com.mirth.connect.client.core.ControllerException;
+import com.mirth.connect.model.ServerSettings;
 import com.mirth.connect.model.alert.AlertModel;
 import com.mirth.connect.server.controllers.ConfigurationController;
 
 public class Alert {
+    private Logger logger = LogManager.getLogger(this.getClass());
 
     public static Class<?> USER_PROTOCOL_CLASS;
-    
+
     private AlertModel model;
     private Long enabledDateTime;
     private Long enabledNanoTime;
@@ -58,9 +66,24 @@ public class Alert {
         context.put("alertId", model.getId());
         context.put("alertName", model.getName());
         context.put("serverId", ConfigurationController.getInstance().getServerId());
+        context.putAll(getServerSettings());
         context.put("date", new DateTool());
 
         return context;
+    }
+
+    private Map<String, Object> getServerSettings() {
+        try {
+            ServerSettings settings = ConfigurationController.getInstance().getServerSettings();
+            // ensure an empty string as Velocity won't replace when given a null value
+            return Map.ofEntries(
+                entry("serverName", StringUtils.defaultString(settings.getServerName())),
+                entry("environmentName", StringUtils.defaultString(settings.getEnvironmentName())));
+        } catch (ControllerException e) {
+            logger.warn("Failed to retrieve server settings", e);
+        }
+
+        return Map.of();
     }
 
     public int getAlertedCount() {


### PR DESCRIPTION
Adds "serverName" and "environmentName" to the alert template variable list.
Requires Java 9+.
Requires an update to the documentation.

Test procedure:
- Compile this patch with Java 9+ and start server
- Login and get past initial account setup
- Set Server Name and Environment Name under Settings tab
- Import and deploy the two attached channels
- Import the attached alert
- Open the imported alert and validate two additional options are present on the right-hand side: "serverName" and "environmentName"
- Validate the two additional options can be copied into the template text area
- Send any message to channel "throws error"
- Validate the resulting text in channel "Receiver" contains the Server Name and Environment Name as you defined in the Settings tab
- Clear the Server Name and Environment Name under Settings tab, then re-run a message to ensure the alert template's values are replaced with empty strings

[throws error.xml.txt](https://github.com/user-attachments/files/16313981/throws.error.xml.txt)
[Receiver.xml.txt](https://github.com/user-attachments/files/16313983/Receiver.xml.txt)
[Foo alert.xml.txt](https://github.com/user-attachments/files/16313982/Foo.alert.xml.txt)
