### PR TITLE
Update Migrate4_5_2.java to allow for log4j2-cli.properties not being present

### DIFF
--- a/server/src/com/mirth/connect/server/migration/Migrate4_5_2.java
+++ b/server/src/com/mirth/connect/server/migration/Migrate4_5_2.java
@@ -36,7 +36,11 @@ public class Migrate4_5_2 extends Migrator implements ConfigurationMigrator {
 
             builder.save();
             
-            // Update log4j2-cli.properties
+            // Update log4j2-cli.properties the file exists
+            if(!new File(ClassPathResource.getResourceURI("log4j2-cli.properties")).exists()) {
+		return;
+	    })
+
             builder = PropertiesConfigurationUtil.createBuilder(new File(ClassPathResource.getResourceURI("log4j2-cli.properties")));
             log4jproperties = builder.getConfiguration();
 


### PR DESCRIPTION
Added a check to see if log4j2-cli.properties exists before adding it to the builder. Not having the CLI installed is a valid use case. I had my 4.5.1 to 4.5.2 upgrade fail if the log4j2-cli.properties file was not in the /conf directory.